### PR TITLE
Adapt cell editor widget to work with CodeEditor

### DIFF
--- a/src/codeeditor/editor.ts
+++ b/src/codeeditor/editor.ts
@@ -6,6 +6,10 @@ import {
 } from 'phosphor/lib/core/disposable';
 
 import {
+  find
+} from 'phosphor/lib/algorithm/searching';
+
+import {
   Message
 } from 'phosphor/lib/core/messaging';
 
@@ -24,6 +28,10 @@ import {
 import {
   ObservableVector
 } from '../common/observablevector';
+
+import {
+  JSONObject
+} from 'phosphor/lib/algorithm/json';
 
 
 /**
@@ -145,6 +153,11 @@ namespace CodeEditor {
     readonly selections: ObservableVector<ITextSelection>;
 
     /**
+     * Returns the primary cursor position.
+     */
+    getCursorPosition(): IPosition;
+
+    /**
      * Returns the content for the given line number.
      */
     getLine(line: number): string;
@@ -190,7 +203,7 @@ namespace CodeEditor {
    * A widget that provides a code editor.
    */
   export
-  interface IEditor extends Widget {
+  interface IEditor extends IDisposable {
     /**
      * Whether line numbers should be displayed. Defaults to false.
      */
@@ -234,6 +247,11 @@ namespace CodeEditor {
      * Brings browser focus to this editor text.
      */
     focus(): void;
+
+    /**
+     * Repaint editor. 
+     */
+    refresh(): void;
 
     /**
      * Test whether the editor has keyboard focus.
@@ -353,6 +371,18 @@ namespace CodeEditor {
      */
     get selections(): ObservableVector<ITextSelection> {
       return this._selections;
+    }
+
+    /**
+     * Returns the primary cursor position.
+     */
+    getCursorPosition(): IPosition {
+      let selections = this.selections;
+      let cursor = find(selections, (selection) => { return selection.start === selection.end; });
+      if (cursor) {
+        return this.getPositionAt(cursor.start);
+      }
+      return null;
     }
 
     /**
@@ -503,6 +533,11 @@ class TextAreaEditor extends Widget implements CodeEditor.IEditor {
   hasFocus(): boolean {
     return document.activeElement === this.node;
   }
+
+  /**
+   * Repaint the editor.
+   */
+  refresh(): void { /* no-op */ }
 
   /**
    * Set the size of the editor in pixels.

--- a/src/codeeditor/index.ts
+++ b/src/codeeditor/index.ts
@@ -6,10 +6,6 @@ import {
   CodeEditor
 } from './editor';
 
-import {
-  Widget
-} from 'phosphor/lib/ui/widget';
-
 export * from './widget';
 export * from './editor';
 
@@ -21,9 +17,6 @@ export
 const IEditorFactory = new Token<IEditorFactory>('jupyter.services.editorfactory');
 /* tslint:enable */
 
-export
-type EditorFactory = (host: Widget) => CodeEditor.IEditor;
-
 /**
  * The editor factory interface.
  */
@@ -33,11 +26,11 @@ interface IEditorFactory {
   /**
    * Create a new editor for inline code.
    */
-  newInline(options: CodeEditor.IOptions): CodeEditor.IEditor;
+  newInlineEditor(host: HTMLElement, options: CodeEditor.IOptions): CodeEditor.IEditor;
 
   /**
    * Create a new editor for a full document.
    */
-  newDocument(options: CodeEditor.IOptions): CodeEditor.IEditor;
+  newDocumentEditor(host: HTMLElement, options: CodeEditor.IOptions): CodeEditor.IEditor;
 
 }

--- a/src/codemirror/model.ts
+++ b/src/codemirror/model.ts
@@ -5,6 +5,10 @@ import * as CodeMirror
   from 'codemirror';
 
 import {
+  find
+} from 'phosphor/lib/algorithm/searching';
+
+import {
   ISignal, clearSignalData, defineSignal
 } from 'phosphor/lib/core/signaling';
 
@@ -116,6 +120,18 @@ class CodeMirrorModel implements CodeEditor.IModel {
    */
   get selections(): ObservableVector<CodeEditor.ITextSelection> {
     return this._selections;
+  }
+
+  /**
+   * Returns the primary cursor position.
+   */
+  getCursorPosition(): CodeEditor.IPosition {
+    let selections = this.selections;
+    let cursor = find(selections, (selection) => { return selection.start === selection.end; });
+    if (cursor) {
+      return this.getPositionAt(cursor.start);
+    }
+    return null;
   }
 
   /**

--- a/src/console/codemirror/widget.ts
+++ b/src/console/codemirror/widget.ts
@@ -101,9 +101,9 @@ namespace CodeMirrorConsoleRenderer {
   export
   const defaultCodeCellRenderer = new CodeMirrorCodeCellWidgetRenderer({
     editorInitializer: (editor) => {
-      editor.editor.setOption('matchBrackets', false);
-      editor.editor.setOption('autoCloseBrackets', false);
-      editor.editor.setOption('extraKeys', {
+      editor.setOption('matchBrackets', false);
+      editor.setOption('autoCloseBrackets', false);
+      editor.setOption('extraKeys', {
         Enter: function() { /* no-op */ }
       });
     }

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -37,6 +37,10 @@ import {
   IEditorTracker
 } from './index';
 
+import {
+  CodeMirrorEditor, DEFAULT_CODEMIRROR_THEME
+} from '../codemirror/editor';
+
 import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/edit/closebrackets.js';
 import 'codemirror/addon/comment/comment.js';
@@ -112,7 +116,7 @@ function activateEditorHandler(app: JupyterLab, registry: IDocumentRegistry, mai
   });
   registry.addWidgetFactory(widgetFactory);
 
-  mainMenu.addMenu(createMenu(app), {rank: 30});
+  mainMenu.addMenu(createMenu(app), { rank: 30 });
 
   let commands = app.commands;
 
@@ -203,9 +207,8 @@ const sessionIdProperty = new AttachedProperty<EditorWidget, string>({ name: 'se
  */
 function toggleLineNums() {
   if (tracker.currentWidget) {
-    let editor = tracker.currentWidget.editor;
-    // TODO move to codemirror
-    // editor.setOption('lineNumbers', !editor.getOption('lineNumbers'));
+    let editor = tracker.currentWidget.editor as CodeMirrorEditor;
+    editor.editor.setOption('lineNumbers', !editor.editor.getOption('lineNumbers'));
   }
 }
 
@@ -215,9 +218,8 @@ function toggleLineNums() {
  */
 function toggleLineWrap() {
   if (tracker.currentWidget) {
-    let editor = tracker.currentWidget.editor;
-    // TODO move to codemirror
-    // editor.setOption('lineWrapping', !editor.getOption('lineWrapping'));
+    let editor = tracker.currentWidget.editor as CodeMirrorEditor;
+    editor.editor.setOption('lineWrapping', !editor.editor.getOption('lineWrapping'));
   }
 }
 
@@ -227,9 +229,8 @@ function toggleLineWrap() {
  */
 function toggleMatchBrackets() {
   if (tracker.currentWidget) {
-    let editor = tracker.currentWidget.editor;
-    // TODO move to codemirror
-    // editor.setOption('matchBrackets', !editor.getOption('matchBrackets'));
+    let editor = tracker.currentWidget.editor as CodeMirrorEditor;
+    editor.editor.setOption('matchBrackets', !editor.editor.getOption('matchBrackets'));
   }
 }
 
@@ -239,10 +240,10 @@ function toggleMatchBrackets() {
  */
 function toggleVim() {
   tracker.forEach(widget => {
-    // TODO move to codemirror
-    // let keymap = widget.editor.getOption('keyMap') === 'vim' ? 'default'
-    //   : 'vim';
-    // widget.editor.setOption('keyMap', keymap);
+    let editor = widget.editor as CodeMirrorEditor;
+    let keymap = editor.editor.getOption('keyMap') === 'vim' ? 'default'
+      : 'vim';
+    editor.editor.setOption('keyMap', keymap);
   });
 }
 
@@ -273,16 +274,18 @@ function createMenu(app: JupyterLab): Menu {
   settings.addItem({ command: cmdIds.matchBrackets });
   settings.addItem({ command: cmdIds.vimMode });
 
-  // TODO move to codemirror
-  // commands.addCommand(cmdIds.changeTheme, {
-  //   label: args => {
-  //     return args['theme'] as string;
-  //   },
-  //   execute: args => {
-  //     let name: string = args['theme'] as string || DEFAULT_CODEMIRROR_THEME;
-  //     tracker.forEach(widget => { widget.editor.setOption('theme', name); });
-  //   }
-  // });
+  commands.addCommand(cmdIds.changeTheme, {
+    label: args => {
+      return args['theme'] as string;
+    },
+    execute: args => {
+      let name: string = args['theme'] as string || DEFAULT_CODEMIRROR_THEME;
+      tracker.forEach(widget => {
+        let editor = widget.editor as CodeMirrorEditor;
+        editor.editor.setOption('theme', name);
+      });
+    }
+  });
 
   [
    'jupyter', 'default', 'abcdef', 'base16-dark', 'base16-light',

--- a/src/editorwidget/widget.ts
+++ b/src/editorwidget/widget.ts
@@ -66,11 +66,12 @@ class EditorWidget extends CodeEditorWidget {
   /**
    * Construct a new editor widget.
    */
-  constructor(editor: CodeEditor.IEditor, context: DocumentRegistry.IContext<DocumentRegistry.IModel>) {
-    super(editor);
+  constructor(editorFactory: (host: Widget) => CodeEditor.IEditor, context: DocumentRegistry.IContext<DocumentRegistry.IModel>) {
+    super(editorFactory);
     this.addClass(EDITOR_CLASS);
     this._context = context;
     let model = context.model;
+    let editor = this.editor;
     editor.model.value = model.toString();
     this.title.label = context.path.split('/').pop();
     model.stateChanged.connect((m, args) => {
@@ -126,12 +127,14 @@ class EditorWidgetFactory extends ABCWidgetFactory<EditorWidget, DocumentRegistr
    * Create a new widget given a context.
    */
   protected createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): EditorWidget {
-    let editor = this._editorFactory.newDocument({
-        lineNumbers: true,
-        readOnly: false,
-        wordWrap: true,
-    });
-    return new EditorWidget(editor, context);
+    return new EditorWidget((host: Widget) => {
+      let editor = this._editorFactory.newDocumentEditor(host.node, {
+          lineNumbers: true,
+          readOnly: false,
+          wordWrap: true,
+      });
+      return editor;
+    }, context);
   }
 
   private _editorFactory: IEditorFactory = null;

--- a/src/notebook/codemirror/cells/widget.ts
+++ b/src/notebook/codemirror/cells/widget.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
   ICellEditorWidget
 } from '../../cells/editor';
 
@@ -10,7 +14,11 @@ import {
 } from '../../cells/widget';
 
 import {
-  CodeMirrorCellEditorWidget
+  CodeMirrorEditor
+} from '../../../codemirror/editor';
+
+import {
+  CodeCellEditorWidget
 } from './editor';
 
 
@@ -36,13 +44,17 @@ class CodeMirrorCodeCellWidgetRenderer extends CodeCellWidget.Renderer {
    * Construct a code cell widget.
    */
   createCellEditor(): ICellEditorWidget {
-    const widget = new CodeMirrorCellEditorWidget(this._editorConfiguration);
-    this._editorInitializer(widget);
+    let configuration = this._editorConfiguration;
+
+    const widget = new CodeCellEditorWidget((host: Widget) => {
+      return new CodeMirrorEditor(host.node, configuration);
+    });
+    this._editorInitializer((widget.editor as CodeMirrorEditor).editor);
     return widget;
   }
 
   private _editorConfiguration: CodeMirror.EditorConfiguration = null;
-  private _editorInitializer: (editor: CodeMirrorCellEditorWidget) => void = null;
+  private _editorInitializer: (editor: CodeMirror.Editor) => void = null;
 }
 
 
@@ -64,7 +76,7 @@ namespace CodeMirrorCodeCellWidgetRenderer {
     /**
      * A code cell widget initializer function.
      */
-    editorInitializer?: (editor: CodeMirrorCellEditorWidget) => void;
+    editorInitializer?: (editor: CodeMirror.Editor) => void;
   }
 
   /**

--- a/src/notebook/codemirror/notebook/widget.ts
+++ b/src/notebook/codemirror/notebook/widget.ts
@@ -90,8 +90,8 @@ namespace CodeMirrorNotebookRenderer {
   export
   const defaultCodeCellRenderer = new CodeMirrorCodeCellWidgetRenderer({
     editorInitializer: (editor) => {
-      editor.editor.setOption('matchBrackets', true);
-      editor.editor.setOption('autoCloseBrackets', true);
+      editor.setOption('matchBrackets', true);
+      editor.setOption('autoCloseBrackets', true);
     }
   });
 
@@ -102,7 +102,7 @@ namespace CodeMirrorNotebookRenderer {
   const defaultMarkdownCellRenderer = new CodeMirrorCodeCellWidgetRenderer({
     editorInitializer: (editor) => {
       // Turn on line wrapping for markdown cells.
-      editor.editor.setOption('lineWrapping', true);
+      editor.setOption('lineWrapping', true);
     }
   });
 
@@ -113,7 +113,7 @@ namespace CodeMirrorNotebookRenderer {
   const defaultRawCellRenderer = new CodeMirrorCodeCellWidgetRenderer({
     editorInitializer: (editor) => {
       // Turn on line wrapping for markdown cells.
-      editor.editor.setOption('lineWrapping', true);
+      editor.setOption('lineWrapping', true);
     }
   });
 


### PR DESCRIPTION
Updated CodeEditor:

* remove Widget as super type of CodeEditor
* add #refresh operation
* rename IEditorFactory operations
* adapt cell editor widget to work with CodeEditor

cc @akosyakov